### PR TITLE
fix(deploy): GitHub Pages Actions 배포로 전환

### DIFF
--- a/.codex/rules/deployment.md
+++ b/.codex/rules/deployment.md
@@ -11,7 +11,7 @@
 - `.github/workflows/ci.yml`은 `master` 대상 PR과 `master` push에서 실행됩니다.
 - CI는 `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run build`만 수행합니다.
 - `.github/workflows/deploy.yml`은 `master` push 중 `content/**`, `assets/**`, `static/**`, `gatsby-meta-config.ts` 변경이 포함될 때 실행됩니다.
-- Deploy workflow는 `pnpm install --frozen-lockfile` 후 `pnpm run deploy`로 GitHub Pages 배포를 수행합니다.
+- Deploy workflow는 `pnpm install --frozen-lockfile`, `pnpm run build`, `CNAME` 복사 후 GitHub Pages 전용 Actions로 `public/` artifact를 업로드하고 배포합니다.
 
 ## 배포 대상
 
@@ -31,4 +31,5 @@
 - Firebase와 Google Analytics 값은 환경 변수로 주입합니다.
 - `public/`과 `.cache/`는 생성 산출물로 취급하고 직접 수정하지 않습니다.
 - Gatsby 캐시로 인해 이상 동작이 보이면 `pnpm run clean` 또는 `pnpm run start`를 사용합니다.
-- 자동 배포는 `gh-pages` 브랜치에 원격 쓰기 side effect를 만들므로 workflow 권한은 `contents: write`가 필요합니다.
+- GitHub Pages 전용 Actions 기반 자동 배포는 workflow 권한으로 `contents: read`, `pages: write`, `id-token: write`가 필요합니다.
+- 저장소 Pages 설정의 Build and deployment Source는 `GitHub Actions`여야 합니다.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,9 @@ name: Deploy
       - gatsby-meta-config.ts
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 env:
   CI: true
@@ -22,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Build and deploy GitHub Pages
+  build:
+    name: Build GitHub Pages artifact
     runs-on: ubuntu-latest
 
     steps:
@@ -44,10 +46,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Configure git author
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
 
-      - name: Deploy
-        run: pnpm run deploy
+      - name: Build
+        run: pnpm run build
+
+      - name: Copy CNAME
+        run: cp CNAME public/CNAME
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+  deploy:
+    name: Deploy GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy GitHub Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/conductor.json
+++ b/conductor.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "setup": "pnpm install",
-    "run": "pnpm run develop",
+    "run": "pnpm run develop -- --port \"$CONDUCTOR_PORT\"",
     "archive": "pnpm run clean"
   },
-  "runScriptMode": "nonconcurrent"
+  "runScriptMode": "concurrent"
 }


### PR DESCRIPTION
## 요약

- GitHub Pages 자동 배포를 `gh-pages` CLI push 방식에서 GitHub Pages 전용 Actions 방식으로 전환했습니다.
- Conductor Run 스크립트가 workspace별 `CONDUCTOR_PORT`를 유지하도록 복원했습니다.

## 변경 사항

- Deploy workflow를 `build`와 `deploy` job으로 분리
- `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages` 기반 배포로 변경
- workflow 권한을 `contents: read`, `pages: write`, `id-token: write`로 정리
- `CNAME`을 `public/CNAME`으로 복사한 뒤 Pages artifact를 업로드하도록 구성
- 배포 문서를 GitHub Pages Actions 기준으로 갱신
- Conductor Run 스크립트의 포트 전달과 concurrent 실행 모드 복원

## 영향 범위

- [ ] 콘텐츠 / 포스트
- [ ] Gatsby / React UI
- [ ] 사이트 메타데이터 / SEO
- [ ] Firebase / 댓글 / 외부 서비스
- [x] GitHub Pages 배포
- [x] 문서 / AI 워크플로우

## 검증

- [x] `pnpm run lint`
- [ ] `pnpm run build`
- [x] 수동 검증: deploy workflow YAML 파싱, `conductor.json` JSON 파싱, `git diff --check`

## 배포 영향

- [ ] 배포 영향 없음
- [x] `master` 머지 후 자동 배포 대상 변경 포함
- [ ] 환경 변수 변경 필요
- [x] CNAME / GitHub Pages 영향 검토 필요
- [ ] 배포 명령 수동 실행 필요

## 참고 사항

- 직전 실패는 Gatsby build가 아니라 `gh-pages -d public -x` push 단계에서 발생했습니다.
- GitHub Pages 전용 Actions를 쓰려면 저장소 Pages 설정의 Source가 `GitHub Actions`로 설정되어 있어야 합니다.