### PR TITLE
fix: Firebase secret 배포 주입 추가

### DIFF
--- a/.codex/rules/deployment.md
+++ b/.codex/rules/deployment.md
@@ -11,6 +11,8 @@
 - `.github/workflows/ci.yml`은 `master` 대상 PR과 `master` push에서 실행됩니다.
 - CI의 `validate` job은 `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run build`를 수행합니다.
 - CI의 `deploy` job은 `master` push에서만 실행되며, `validate` 성공 후 `pnpm run build`, `CNAME` 복사, `public/` 디렉터리의 GitHub Pages artifact 업로드와 배포를 수행합니다.
+- `deploy` job의 production build는 GitHub Secrets의 Firebase/Analytics 환경 변수를 주입합니다.
+- `deploy` job은 Firebase 런타임 설정에 필요한 `FIREBASE_*` secret이 비어 있으면 build 전에 실패해야 합니다.
 
 ## 배포 대상
 
@@ -28,7 +30,7 @@
 ## 주의사항
 
 - `.env`는 커밋하지 않습니다.
-- Firebase와 Google Analytics 값은 환경 변수로 주입합니다.
+- Firebase와 Google Analytics 값은 로컬에서는 `.env`, CI 배포에서는 GitHub Secrets로 주입합니다.
 - `public/`과 `.cache/`는 생성 산출물로 취급하고 직접 수정하지 않습니다.
 - Gatsby 캐시로 인해 이상 동작이 보이면 `pnpm run clean` 또는 `pnpm run start`를 사용합니다.
 - GitHub Pages Actions 기반 자동 배포는 deploy job의 `contents: read`, `pages: write`, `id-token: write` 권한이 필요합니다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    env:
+      GOOGLE_TRAKING_ID: ${{ secrets.GOOGLE_TRAKING_ID }}
+      FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+      FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+      FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
 
     permissions:
       contents: read
@@ -83,6 +92,29 @@ jobs:
 
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
+
+      - name: Validate production environment
+        run: |
+          missing=false
+
+          for name in \
+            FIREBASE_API_KEY \
+            FIREBASE_AUTH_DOMAIN \
+            FIREBASE_DATABASE_URL \
+            FIREBASE_PROJECT_ID \
+            FIREBASE_STORAGE_BUCKET \
+            FIREBASE_MESSAGING_SENDER_ID \
+            FIREBASE_APP_ID
+          do
+            if [ -z "${!name}" ]; then
+              echo "::error title=Missing deploy secret::$name is required for Firebase runtime configuration."
+              missing=true
+            fi
+          done
+
+          if [ "$missing" = "true" ]; then
+            exit 1
+          fi
 
       - name: Build
         run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pnpm run deploy
 ## 환경 변수
 
 Firebase/Analytics 설정은 환경 변수로 관리합니다. 필요 변수는 `gatsby-meta-config.ts`를 참고하세요.
+GitHub Actions 배포에서는 같은 이름의 GitHub Secrets를 설정해야 하며, Firebase secret이 비어 있으면 deploy job이 빌드 전에 실패합니다.
 
 ```
 # .env.example


### PR DESCRIPTION
## 요약

- GitHub Pages deploy job에 Firebase/Analytics secret을 주입합니다.
- Firebase 필수 secret이 비어 있으면 배포 빌드 전에 실패하도록 검증 단계를 추가합니다.
- CI 배포 환경 변수 주입 방식을 README와 배포 규칙 문서에 반영합니다.

## 변경 사항

- `.github/workflows/ci.yml` deploy job에 `FIREBASE_*`, `GOOGLE_TRAKING_ID` env 매핑 추가
- deploy build 전 `Validate production environment` 단계 추가
- README와 `.codex/rules/deployment.md`에 GitHub Secrets 기반 배포 설정 안내 추가

## 영향 범위

- [ ] 콘텐츠 / 포스트
- [ ] Gatsby / React UI
- [ ] 사이트 메타데이터 / SEO
- [x] Firebase / 댓글 / 외부 서비스
- [x] GitHub Pages 배포
- [x] 문서 / AI 워크플로우

## 검증

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] 수동 검증:

## 배포 영향

- [ ] 배포 영향 없음
- [x] `master` 머지 후 자동 배포 대상 변경 포함
- [x] 환경 변수 변경 필요
- [x] CNAME / GitHub Pages 영향 검토 필요
- [ ] 배포 명령 수동 실행 필요

## 참고 사항

- GitHub Actions Repository secrets에 Firebase 필수 값이 없으면 deploy job이 빌드 전에 실패합니다.
- `GOOGLE_TRAKING_ID`는 주입하지만 필수 검증 대상에는 포함하지 않았습니다.