### PR TITLE
feat: About 페이지에 요즘IT 게시글 추가

### DIFF
--- a/gatsby-meta-config.ts
+++ b/gatsby-meta-config.ts
@@ -209,6 +209,12 @@ const metaConfig: MetaConfig = {
         },
         posts: [
           {
+            title: '이벤트 기반 MSA, AI 시대엔 더 비싸진다고요?',
+            thumbnail: 'https://yozm.wishket.com/media/news/3839/thumbnail.png',
+            publishedAt: '2026-07-08T09:00:17+09:00',
+            url: 'https://yozm.wishket.com/magazine/detail/3839/',
+          },
+          {
             title: 'cURL은 왜 버그 바운티를 끝냈을까?',
             thumbnail: 'https://yozm.wishket.com/media/news/3668/thumbnail.jpg',
             publishedAt: '2026-03-23T09:00:17+09:00',


### PR DESCRIPTION
## 요약

- About 페이지의 요즘IT 섹션에 새로 발행한 기고 글을 추가합니다.

## 변경 사항

- 요즘IT 게시글 목록에 `이벤트 기반 MSA, AI 시대엔 더 비싸진다고요?`를 추가했습니다.
- 원문 공개 메타데이터를 기준으로 제목, 썸네일, 발행일, URL을 반영했습니다.

## 영향 범위

- [ ] 콘텐츠 / 포스트
- [ ] Gatsby / React UI
- [x] 사이트 메타데이터 / SEO
- [x] Firebase / 댓글 / 외부 서비스
- [ ] GitHub Pages 배포
- [ ] 문서 / AI 워크플로우

## 검증

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] 수동 검증: 빌드된 About page-data에 새 글 메타데이터가 포함된 것을 확인했습니다.

## 배포 영향

- [ ] 배포 영향 없음
- [x] `master` 머지 후 자동 배포 대상 변경 포함
- [ ] 환경 변수 변경 필요
- [ ] CNAME / GitHub Pages 영향 검토 필요
- [ ] 배포 명령 수동 실행 필요

## 참고 사항

- 타입, 라우팅, slug, 카테고리, Firebase 및 배포 설정 변경은 없습니다.
- 요즘IT 외부 링크와 썸네일 메타데이터만 추가했습니다.