### PR TITLE
fix: 블로그 초기 진입 안정성 개선

### DIFF
--- a/.codex/rules/firebase.md
+++ b/.codex/rules/firebase.md
@@ -9,11 +9,11 @@
 
 ## 사용 위치
 
-- Firebase 초기화와 Realtime Database 접근은 페이지 또는 템플릿에서 명시적으로 구성합니다.
-- 현재 조회수 기능은 `src/templates/blog-template.tsx`와 `src/templates/category-template.tsx`에서 Realtime Database를 직접 읽습니다.
+- Firebase 초기화와 Realtime Database 접근은 페이지 또는 템플릿에서 명시적으로 구성하고, 동일한 읽기 로직을 여러 화면에서 사용할 때만 `src/utils/`로 분리합니다.
+- 포스트 목록 조회수 읽기는 `src/utils/viewCounts.ts`를 통해 홈과 카테고리 템플릿에서 공유하며, 상세 페이지의 조회수 읽기/쓰기는 `src/templates/blog-template.tsx`에서 처리합니다.
 - 조회수 경로는 `posts/<slug에서 슬래시를 제거한 키>` 형식입니다.
 - 개발 환경에서는 상세 페이지 조회수를 증가시키지 않습니다.
-- 여러 위치에서 재사용되는 로직만 `src/utils/` 등 공용 유틸로 분리합니다.
+- 조회수 읽기는 포스트 목록 렌더링을 차단하지 않으며, 실패 시 조회수 없는 기본 UI를 유지합니다.
 - 클라이언트에서 노출되면 안 되는 값은 Gatsby 공개 환경 변수로 전달하지 않습니다.
 
 ## 확장 규칙

--- a/.codex/rules/project-context.md
+++ b/.codex/rules/project-context.md
@@ -38,6 +38,7 @@
 - 페이지는 `src/pages/`, 템플릿은 `src/templates/`, 재사용 컴포넌트는 `src/components/`에 둡니다.
 - 콘텐츠는 `content/`에 마크다운 기반으로 관리합니다.
 - 포스트 slug는 `gatsby-node.ts`에서 마크다운 파일의 상위 디렉터리 basename으로 생성합니다.
+- 포스트 신규 여부는 `gatsby-node.ts`에서 빌드 시점 기준 7일 이내인지 계산한 `fields.isNew`로 생성합니다.
 - 카테고리는 frontmatter의 `categories` 문자열을 공백으로 분리해 사용합니다.
 - 전역 스타일은 `src/styles/global.css` 한 곳에서 관리합니다.
 - Tailwind 유틸리티 클래스를 우선하고, 필요한 경우에만 CSS 커스텀 규칙을 추가합니다.

--- a/.codex/rules/react-gatsby.md
+++ b/.codex/rules/react-gatsby.md
@@ -19,6 +19,7 @@
 
 - 콘텐츠 소스는 `content/`의 마크다운 구조를 기준으로 합니다.
 - `gatsby-node.ts`는 마크다운 상위 디렉터리 basename을 slug로 사용합니다. 포스트 디렉터리명을 바꾸면 URL이 바뀝니다.
+- `gatsby-node.ts`는 빌드 시점 기준 7일 이내 포스트를 `fields.isNew`로 표시하며, 카드와 상세 헤더는 이 값을 사용해 Hydration 결과를 일치시킵니다.
 - 카테고리 목록 페이지는 `createPostsPages`에서 생성하며, `All` 카테고리를 기본으로 포함합니다.
 - 카테고리 필터는 `frontmatter.categories.includes(currentCategory)`를 사용하므로 부분 문자열 충돌 가능성을 고려합니다.
 - 이미지와 정적 자산은 기존 `assets/`와 `static/` 사용 방식을 따릅니다.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -10,6 +10,7 @@ interface MarkdownRemarkNode {
   tableOfContents?: string;
   fields: {
     slug: string;
+    isNew: boolean;
   };
   frontmatter: {
     categories: string;
@@ -40,7 +41,7 @@ interface DefaultThumbnailData {
 type CreatePageFn = CreatePagesArgs['actions']['createPage'];
 
 /**
- * @description 마크다운 노드에 slug 필드를 추가
+ * @description 마크다운 노드에 slug와 신규 여부 필드를 추가
  * @param {GatsbyNode['onCreateNode']} args Gatsby 노드 생성 인자
  * @return {void}
  */
@@ -55,6 +56,18 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, getNode, action
       node,
       name: `slug`,
       value: `/${dirName}/`,
+    });
+
+    const markdownNode = node as unknown as Pick<MarkdownRemarkNode, 'frontmatter'>;
+    const publishedAt = markdownNode.frontmatter.date
+      ? new Date(markdownNode.frontmatter.date).getTime()
+      : Number.NaN;
+    const ageInDays = Math.ceil((Date.now() - publishedAt) / (1000 * 60 * 60 * 24));
+
+    createNodeField({
+      node,
+      name: `isNew`,
+      value: Number.isFinite(publishedAt) && ageInDays <= 7,
     });
   }
 };
@@ -177,6 +190,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions, graphql,
             timeToRead
             fields {
               slug
+              isNew
             }
             frontmatter {
               categories

--- a/src/components/giscus/index.tsx
+++ b/src/components/giscus/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
+import { getValueFromLocalStorage } from '../../utils/localStorage';
 import type { SiteMetadata } from '../../types/site';
 
 const src = 'https://giscus.app/client.js';
@@ -53,7 +54,7 @@ function Giscus({ repo, path }: GiscusProps) {
     if (!repoFromMeta || !repoId || !category || !categoryId) return;
 
     // 테마 정보를 읽어 Giscus 테마를 결정
-    const storedIsDarkMode = localStorage.getItem('isDarkMode');
+    const storedIsDarkMode = getValueFromLocalStorage('isDarkMode') === true;
     const giscus = document.createElement('script');
     const giscusConfig: Record<string, string> = {
       src,
@@ -66,7 +67,7 @@ function Giscus({ repo, path }: GiscusProps) {
       'data-reactions-enabled': '1',
       'data-emit-metadata': '0',
       'data-input-position': 'bottom',
-      'data-theme': JSON.parse(storedIsDarkMode || 'false') ? 'dark' : 'light',
+      'data-theme': storedIsDarkMode ? 'dark' : 'light',
       'data-lang': 'ko',
       crossorigin: 'anonymous',
       async: 'true',

--- a/src/components/page-footer/index.tsx
+++ b/src/components/page-footer/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface PageFooterProps {
   author: string;
   githubUrl: string;
+  year: string;
 }
 
 /**
@@ -10,11 +11,11 @@ interface PageFooterProps {
  * @param {PageFooterProps} props 푸터 props
  * @return {JSX.Element}
  */
-function PageFooter({ author, githubUrl }: PageFooterProps) {
+function PageFooter({ author, githubUrl, year }: PageFooterProps) {
   return (
     <footer className="mt-auto border-t border-[var(--post-card-border-color)] py-6">
       <p className="text-center text-[13px] text-[var(--secondary-text-color)] md:text-[14px]">
-        © {new Date().getFullYear()}
+        © {year}
         &nbsp;
         <a
           href={githubUrl}

--- a/src/components/post-card-column/index.tsx
+++ b/src/components/post-card-column/index.tsx
@@ -9,7 +9,6 @@ interface PostCardColumnProps {
   showMoreButton?: boolean;
   moreUrl: string;
   defaultThumbnail?: GatsbyImageFile;
-  loadingViews?: boolean;
 }
 
 /**
@@ -22,7 +21,6 @@ function PostCardColumn({
   showMoreButton,
   moreUrl,
   defaultThumbnail,
-  loadingViews,
 }: PostCardColumnProps) {
   /**
    * @description 더보기 버튼 클릭 핸들러
@@ -33,22 +31,13 @@ function PostCardColumn({
     navigate(moreUrl);
   }, [moreUrl]);
 
-  const postsToRender: Array<PostModel | undefined> = loadingViews
-    ? Array.from({ length: posts.length || 4 })
-    : posts;
-
   return (
     <div className="mt-2 flex w-full justify-center">
       <div className="flex w-full flex-col items-center">
-        {postsToRender.map((post, index) => (
-          <PostCard
-            key={loadingViews ? `skeleton-${index}` : (post?.id ?? `post-${index}`)}
-            post={post}
-            defaultThumbnail={defaultThumbnail}
-            isLoading={loadingViews}
-          />
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} defaultThumbnail={defaultThumbnail} />
         ))}
-        {showMoreButton && !loadingViews && (
+        {showMoreButton && (
           <button
             className="mt-8 h-10 rounded-md border border-[var(--post-card-border-color)] px-4 text-[13px] font-semibold uppercase tracking-[0.08em] text-[var(--secondary-text-color)] transition-colors duration-200 hover:border-[var(--primary-text-color)] hover:text-[var(--primary-text-color)]"
             onClick={onMoreButtonClick}

--- a/src/components/post-card/index.tsx
+++ b/src/components/post-card/index.tsx
@@ -6,30 +6,11 @@ import type { PostModel } from '../../types/post';
 import type { GatsbyImageFile } from '../../types/image';
 
 interface PostCardProps {
-  post?: PostModel;
+  post: PostModel;
   defaultThumbnail?: GatsbyImageFile;
-  isLoading?: boolean;
 }
 
-function PostCard({ post, defaultThumbnail, isLoading }: PostCardProps) {
-  if (isLoading) {
-    return (
-      <div className="w-full border-b border-[var(--post-card-border-color)] py-7 animate-pulse">
-        <div className="mb-3 h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-4 h-7 w-3/4 rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-4 h-4 w-full rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-4 h-4 w-5/6 rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div className="flex items-center gap-3">
-          <div className="h-3 w-20 rounded bg-gray-200 dark:bg-gray-700"></div>
-          <div className="h-3 w-14 rounded bg-gray-200 dark:bg-gray-700"></div>
-          <div className="h-3 w-16 rounded bg-gray-200 dark:bg-gray-700"></div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!post) return null;
-
+function PostCard({ post, defaultThumbnail }: PostCardProps) {
   const {
     id,
     slug,
@@ -41,9 +22,8 @@ function PostCard({ post, defaultThumbnail, isLoading }: PostCardProps) {
     views,
     timeToRead,
     tableOfContents,
+    isNew,
   } = post;
-  const isNew =
-    Math.ceil((new Date().getTime() - new Date(date).getTime()) / (1000 * 3600 * 24)) <= 7;
 
   const isExternalImage =
     typeof thumbnail === 'string' &&

--- a/src/components/post-header/index.tsx
+++ b/src/components/post-header/index.tsx
@@ -16,15 +16,12 @@ interface PostHeaderProps {
  */
 function PostHeader({ post, viewCount }: PostHeaderProps) {
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
-  // 7일 이내 게시글은 신규 표시
-  const isNew =
-    Math.ceil((new Date().getTime() - new Date(post.date).getTime()) / (1000 * 3600 * 24)) <= 7;
 
   return (
     <header className="w-full border-b border-[var(--post-card-border-color)] pb-9 pt-10 break-keep md:pt-12">
       <h1 className="title mb-4 text-[29px] font-extrabold leading-[1.25] tracking-[-0.02em] text-[var(--primary-text-color)] md:text-[35px]">
         {post.title}
-        {isNew && (
+        {post.isNew && (
           <span className="ml-2 inline-flex rounded-md bg-red-50 px-2.5 py-[2px] align-middle text-[12px] font-bold uppercase tracking-[0.05em] text-red-500 dark:bg-red-900/30 dark:text-red-300 md:text-[13px]">
             New
           </span>

--- a/src/components/post-tabs/index.tsx
+++ b/src/components/post-tabs/index.tsx
@@ -15,7 +15,6 @@ interface PostTabsProps {
   defaultThumbnail?: GatsbyImageFile;
   sortType: SortType;
   onSortChange: (event: { target: { value: SortType } }) => void;
-  loadingViews?: boolean;
 }
 
 /**
@@ -32,7 +31,6 @@ function PostTabs({
   defaultThumbnail,
   sortType,
   onSortChange,
-  loadingViews,
 }: PostTabsProps) {
   const tabPosts = useMemo(() => {
     // 선택 탭에 맞는 포스트만 필터링
@@ -70,7 +68,6 @@ function PostTabs({
         showMoreButton={showMoreButton && tabPosts.length > 4}
         moreUrl={`posts/${tabIndex === 0 ? '' : tabs[tabIndex]}`}
         defaultThumbnail={defaultThumbnail}
-        loadingViews={loadingViews} // Pass loading state down
       />
     </section>
   );

--- a/src/components/theme-switch/index.tsx
+++ b/src/components/theme-switch/index.tsx
@@ -7,28 +7,36 @@ import { getValueFromLocalStorage, setValueToLocalStorage } from '../../utils/lo
  * @return {JSX.Element}
  */
 function ThemeSwitch() {
-  // 로컬스토리지 초기값을 안전하게 파싱
-  const storedValue = getValueFromLocalStorage('isDarkMode');
-  const initialIsDarkMode = typeof storedValue === 'boolean' ? storedValue : false;
-  const [isDarkMode, setIsDarkMode] = useState<boolean>(initialIsDarkMode);
+  const [isDarkMode, setIsDarkMode] = useState<boolean>(
+    () => getValueFromLocalStorage('isDarkMode') === true,
+  );
 
   useEffect(() => {
-    // 테마 상태를 로컬스토리지와 DOM 클래스에 반영
     setValueToLocalStorage('isDarkMode', isDarkMode);
     document.documentElement.classList.toggle('dark', isDarkMode);
   }, [isDarkMode]);
 
+  /**
+   * @description 다크모드 상태를 전환하고 브라우저에 저장
+   * @return {void}
+   */
+  const onThemeToggle = () => {
+    setIsDarkMode((currentIsDarkMode) => !currentIsDarkMode);
+  };
+
   return (
     <div className="fixed bottom-[18px] right-[18px] z-30 flex items-center justify-center md:bottom-[22px] md:right-[22px]">
       <button
+        aria-label="테마 전환"
         className="z-30 flex h-[44px] w-[44px] cursor-pointer items-center justify-center rounded-full border border-[var(--post-card-border-color)] bg-[var(--background-color)] shadow-lg"
-        onClick={() => setIsDarkMode((isDark) => !isDark)}
+        onClick={onThemeToggle}
+        type="button"
       >
-        {isDarkMode ? (
-          <MdLightMode className="h-5 w-5 text-yellow-500" />
-        ) : (
-          <MdDarkMode className="h-5 w-5 text-[var(--primary-text-color)]" />
-        )}
+        <MdLightMode aria-hidden="true" className="hidden h-5 w-5 text-yellow-500 dark:block" />
+        <MdDarkMode
+          aria-hidden="true"
+          className="block h-5 w-5 text-[var(--primary-text-color)] dark:hidden"
+        />
       </button>
     </div>
   );

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -6,6 +6,7 @@ import ThemeSwitch from '../components/theme-switch';
 
 interface LayoutQueryData {
   site: {
+    buildTime: string;
     siteMetadata: {
       title: string;
       author: {
@@ -33,6 +34,7 @@ const Layout = ({ children, tableOfContents, contentMaxWidth = 'max-w-[960px]' }
   const data = useStaticQuery<LayoutQueryData>(graphql`
     query SiteTitleQuery {
       site {
+        buildTime(formatString: "YYYY")
         siteMetadata {
           title
           author {
@@ -101,6 +103,7 @@ const Layout = ({ children, tableOfContents, contentMaxWidth = 'max-w-[960px]' }
         <PageFooter
           author={author.name || `Author`}
           githubUrl={author.social?.github || `https://www.github.com`}
+          year={data.site.buildTime}
         />
       </div>
       <ThemeSwitch />

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -17,6 +17,7 @@ export default class Post implements PostModel {
   date: string;
   thumbnail?: string;
   views?: number;
+  isNew?: boolean;
 
   /**
    * @description 포스트 모델 생성자
@@ -36,5 +37,6 @@ export default class Post implements PostModel {
     this.author = node.frontmatter.author;
     this.date = node.frontmatter.date;
     this.thumbnail = node.frontmatter.thumbnail;
+    this.isNew = node.fields.isNew ?? false;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { graphql, navigate, type PageProps } from 'gatsby';
 import { useLocation } from '@gatsbyjs/reach-router';
-import firebase from 'gatsby-plugin-firebase-v9.0';
-import { getDatabase, ref, get } from 'firebase/database';
 import Layout from '../layout';
 import Seo from '../components/seo';
 import Bio from '../components/bio';
 import Post from '../models/post';
 import { getUniqueCategories } from '../utils/helpers';
+import { getPostViewCounts } from '../utils/viewCounts';
 import PostTabs from '../components/post-tabs';
-import type { PostNode, PostModel } from '../types/post';
+import type { PostNode, PostModel, PostViewCounts } from '../types/post';
 import type { SiteMetadata } from '../types/site';
 import type { GatsbyImageFile } from '../types/image';
 
@@ -24,6 +23,24 @@ interface HomePageData {
 }
 
 type SortType = 'date-desc' | 'date-asc' | 'title-asc' | 'views-desc';
+
+const sortTypes: SortType[] = ['date-desc', 'date-asc', 'title-asc', 'views-desc'];
+
+/**
+ * @description Hydration 이후 클라이언트 스냅샷 재확인을 위한 빈 구독
+ * @return {() => void} 구독 해제 함수
+ */
+const subscribeToSortType = () => () => undefined;
+
+/**
+ * @description 쿼리스트링에서 유효한 포스트 정렬 타입을 반환
+ * @param {string} search 쿼리스트링
+ * @return {SortType} 포스트 정렬 타입
+ */
+const getSortType = (search: string): SortType => {
+  const sortType = new URLSearchParams(search).get('sort');
+  return sortTypes.includes(sortType as SortType) ? (sortType as SortType) : 'date-desc';
+};
 
 interface SortChangeEvent {
   target: {
@@ -47,10 +64,11 @@ function HomePage({ data }: HomePageProps) {
   const [tabIndex, setTabIndex] = useState<number>(featuredTabIndex === -1 ? 0 : featuredTabIndex);
 
   const location = useLocation();
-  // 쿼리스트링에서 초기 정렬 타입을 결정
-  const queryParams = new URLSearchParams(location.search);
-  const initialSortType = (queryParams.get('sort') as SortType) || 'date-desc';
-  const [sortType, setSortType] = useState<SortType>(initialSortType);
+  const sortType = useSyncExternalStore<SortType>(
+    subscribeToSortType,
+    () => getSortType(location.search),
+    () => 'date-desc',
+  );
 
   /**
    * @description 탭 변경 핸들러
@@ -70,7 +88,6 @@ function HomePage({ data }: HomePageProps) {
   const onSortChange = useCallback(
     (event: SortChangeEvent) => {
       const newSortType = event.target.value;
-      setSortType(newSortType);
 
       // 정렬 값을 URL에 동기화
       const newQueryParams = new URLSearchParams(location.search);
@@ -80,25 +97,22 @@ function HomePage({ data }: HomePageProps) {
     [location],
   );
 
-  const [viewCounts, setViewCounts] = useState<Record<string, { views?: number }>>({});
-  const [loadingViews, setLoadingViews] = useState<boolean>(true);
+  const [viewCounts, setViewCounts] = useState<PostViewCounts>({});
 
   useEffect(() => {
-    const database = getDatabase(firebase);
-    const postsRef = ref(database, 'posts');
-    get(postsRef)
-      .then((snapshot) => {
-        if (snapshot.exists()) {
-          setViewCounts(snapshot.val() as Record<string, { views?: number }>);
-        }
+    let isActive = true;
+
+    getPostViewCounts()
+      .then((counts) => {
+        if (isActive) setViewCounts(counts);
       })
       .catch((error) => {
         console.error('Firebase read failed: ', error);
-      })
-      .finally(() => {
-        // 조회수 로딩 종료 처리
-        setLoadingViews(false);
       });
+
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   const sortedPosts = useMemo(() => {
@@ -138,7 +152,6 @@ function HomePage({ data }: HomePageProps) {
         defaultThumbnail={data.defaultThumbnail}
         sortType={sortType}
         onSortChange={onSortChange}
-        loadingViews={loadingViews}
       />
     </Layout>
   );
@@ -163,6 +176,7 @@ export const pageQuery = graphql`
           }
           fields {
             slug
+            isNew
           }
         }
       }

--- a/src/templates/blog-template.tsx
+++ b/src/templates/blog-template.tsx
@@ -102,6 +102,7 @@ export const pageQuery = graphql`
       }
       fields {
         slug
+        isNew
       }
     }
 

--- a/src/templates/category-template.tsx
+++ b/src/templates/category-template.tsx
@@ -1,18 +1,35 @@
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useMemo, useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { navigate, type PageProps } from 'gatsby';
 import { useLocation } from '@gatsbyjs/reach-router';
-import firebase from 'gatsby-plugin-firebase-v9.0';
-import { getDatabase, ref, get } from 'firebase/database';
 
 import Layout from '../layout';
 import Seo from '../components/seo';
 import Post from '../models/post';
 import CategoryPageHeader from '../components/category-page-header';
 import PostTabs from '../components/post-tabs';
-import type { PostNode, PostModel } from '../types/post';
+import { getPostViewCounts } from '../utils/viewCounts';
+import type { PostNode, PostModel, PostViewCounts } from '../types/post';
 import type { GatsbyImageFile } from '../types/image';
 
 type SortType = 'date-desc' | 'date-asc' | 'title-asc' | 'views-desc';
+
+const sortTypes: SortType[] = ['date-desc', 'date-asc', 'title-asc', 'views-desc'];
+
+/**
+ * @description Hydration 이후 클라이언트 스냅샷 재확인을 위한 빈 구독
+ * @return {() => void} 구독 해제 함수
+ */
+const subscribeToSortType = () => () => undefined;
+
+/**
+ * @description 쿼리스트링에서 유효한 포스트 정렬 타입을 반환
+ * @param {string} search 쿼리스트링
+ * @return {SortType} 포스트 정렬 타입
+ */
+const getSortType = (search: string): SortType => {
+  const sortType = new URLSearchParams(search).get('sort');
+  return sortTypes.includes(sortType as SortType) ? (sortType as SortType) : 'date-desc';
+};
 
 interface CategoryPageContext {
   edges: Array<{ node: PostNode }>;
@@ -32,10 +49,11 @@ function CategoryTemplate({ pageContext }: CategoryTemplateProps) {
   const { edges, currentCategory, defaultThumbnail, categories } = pageContext;
 
   const location = useLocation();
-  // 쿼리스트링에서 초기 정렬 타입을 결정
-  const queryParams = new URLSearchParams(location.search);
-  const initialSortType = (queryParams.get('sort') as SortType) || 'date-desc';
-  const [sortType, setSortType] = useState<SortType>(initialSortType);
+  const sortType = useSyncExternalStore<SortType>(
+    subscribeToSortType,
+    () => getSortType(location.search),
+    () => 'date-desc',
+  );
 
   const posts: PostModel[] = useMemo(() => edges.map(({ node }) => new Post(node)), [edges]);
 
@@ -67,7 +85,6 @@ function CategoryTemplate({ pageContext }: CategoryTemplateProps) {
   const onSortChange = useCallback(
     (event: { target: { value: SortType } }) => {
       const newSortType = event.target.value;
-      setSortType(newSortType);
 
       // 정렬 값을 URL에 동기화
       const newQueryParams = new URLSearchParams(location.search);
@@ -77,25 +94,22 @@ function CategoryTemplate({ pageContext }: CategoryTemplateProps) {
     [location],
   );
 
-  const [viewCounts, setViewCounts] = useState<Record<string, { views?: number }>>({});
-  const [loadingViews, setLoadingViews] = useState<boolean>(true);
+  const [viewCounts, setViewCounts] = useState<PostViewCounts>({});
 
   useEffect(() => {
-    const database = getDatabase(firebase);
-    const postsRef = ref(database, 'posts');
-    get(postsRef)
-      .then((snapshot) => {
-        if (snapshot.exists()) {
-          setViewCounts(snapshot.val() as Record<string, { views?: number }>);
-        }
+    let isActive = true;
+
+    getPostViewCounts()
+      .then((counts) => {
+        if (isActive) setViewCounts(counts);
       })
       .catch((error) => {
         console.error('Firebase read failed: ', error);
-      })
-      .finally(() => {
-        // 조회수 로딩 종료 처리
-        setLoadingViews(false);
       });
+
+    return () => {
+      isActive = false;
+    };
   }, []);
 
   const sortedPosts = useMemo(() => {
@@ -130,7 +144,6 @@ function CategoryTemplate({ pageContext }: CategoryTemplateProps) {
         defaultThumbnail={defaultThumbnail}
         sortType={sortType}
         onSortChange={onSortChange}
-        loadingViews={loadingViews} // Pass loading state down
       />
     </Layout>
   );

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -15,6 +15,7 @@ export interface PostFrontmatter {
  */
 export interface PostFields {
   slug: string;
+  isNew?: boolean;
 }
 
 /**
@@ -47,4 +48,10 @@ export interface PostModel {
   date: string;
   thumbnail?: string;
   views?: number;
+  isNew?: boolean;
 }
+
+/**
+ * @description Firebase에 저장된 포스트별 조회수 정보
+ */
+export type PostViewCounts = Record<string, { views?: number }>;

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -5,8 +5,13 @@
  */
 export function getValueFromLocalStorage(key: string): unknown {
   if (typeof window === 'undefined') return undefined;
-  const rawValue = window.localStorage.getItem(key);
-  return rawValue ? JSON.parse(rawValue) : undefined;
+
+  try {
+    const rawValue = window.localStorage.getItem(key);
+    return rawValue ? JSON.parse(rawValue) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -17,5 +22,13 @@ export function getValueFromLocalStorage(key: string): unknown {
  */
 export function setValueToLocalStorage(key: string, value: unknown): void {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(key, JSON.stringify(value));
+
+  try {
+    const serializedValue = JSON.stringify(value);
+    if (serializedValue === undefined) return;
+
+    window.localStorage.setItem(key, serializedValue);
+  } catch {
+    return;
+  }
 }

--- a/src/utils/viewCounts.ts
+++ b/src/utils/viewCounts.ts
@@ -1,0 +1,17 @@
+import firebase from 'gatsby-plugin-firebase-v9.0';
+import { get, getDatabase, ref } from 'firebase/database';
+import type { PostViewCounts } from '../types/post';
+
+/**
+ * @description Firebase에서 포스트별 조회수를 조회
+ * @return {Promise<PostViewCounts>} 포스트별 조회수 정보
+ */
+export async function getPostViewCounts(): Promise<PostViewCounts> {
+  const database = getDatabase(firebase);
+  const snapshot = await get(ref(database, 'posts'));
+
+  if (!snapshot.exists()) return {};
+
+  const value: unknown = snapshot.val();
+  return typeof value === 'object' && value !== null ? (value as PostViewCounts) : {};
+}


### PR DESCRIPTION
## 요약

- 초기 진입 시 발생할 수 있는 Hydration 불일치 경로를 제거합니다.
- Firebase 조회 실패나 지연과 관계없이 포스트 목록을 즉시 표시합니다.

## 변경 사항

- 다크 모드 마크업을 고정하고 localStorage 읽기·쓰기 예외를 방어했습니다.
- Giscus 테마 설정도 안전한 저장소 접근 경로로 통일했습니다.
- 조회수 로딩 스켈레톤을 제거하고 조회수를 비동기로 보강하도록 변경했습니다.
- 언마운트 이후 Firebase 응답이 상태를 갱신하지 않도록 처리했습니다.
- `?sort=` 직접 진입과 `New` 배지, 푸터 연도의 Hydration 결과를 고정했습니다.
- Firebase 및 Gatsby source-of-truth 문서를 현재 구조에 맞게 갱신했습니다.

## 영향 범위

- [ ] 콘텐츠 / 포스트
- [x] Gatsby / React UI
- [ ] 사이트 메타데이터 / SEO
- [x] Firebase / 댓글 / 외부 서비스
- [ ] GitHub Pages 배포
- [x] 문서 / AI 워크플로우

## 검증

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm exec tsc --noEmit`
- [x] 수동 검증: 초기 HTML의 홈 포스트 4개·전체 목록 141개·스켈레톤 0개와 저장소 예외 방어 확인

## 배포 영향

- [ ] 배포 영향 없음
- [x] `master` 머지 후 자동 배포 대상 변경 포함
- [ ] 환경 변수 변경 필요
- [ ] CNAME / GitHub Pages 영향 검토 필요
- [ ] 배포 명령 수동 실행 필요

## 참고 사항

- 환경 변수와 Firebase 데이터 경로는 변경하지 않았습니다.
- 실제 브라우저에서 다크 모드 및 `?sort=` 직접 진입 hard reload smoke test를 권장합니다.